### PR TITLE
Bug fixing: Two issues related to the calculation of average scores for students who did not submit self-surveys or received feedback from others.

### DIFF
--- a/app/controllers/semesters_controller.rb
+++ b/app/controllers/semesters_controller.rb
@@ -280,11 +280,15 @@ class SemestersController < ApplicationController
                         name[1].compact!
                         name[2].compact!
                         including_self_scores = name[1] + name[2]
-                        unless name[1].blank?
+
+                        if including_self_scores.present?
                             name.push((including_self_scores.sum / including_self_scores.size.to_f).round(1))
+                        elsif name[2].present?
+                            name.push((name[2].sum / name[2].size.to_f).round(1))
                         else
                             name.push("*Did not submit survey*")
                         end
+
                         name.push((name[2].sum / name[2].size.to_f).round(1))
 
                         # stores the flags for the team

--- a/app/views/semesters/team.html.erb
+++ b/app/views/semesters/team.html.erb
@@ -96,6 +96,7 @@
                 </thead>
                 <tbody>
                 <% @self_submitted_names.each do |name|%>
+                  <% Rails.logger.debug "=== Name data: #{name.inspect} ===" %>
                   <tr>
                     <th><%=name[0]%></th>
                     <td class="<%=if name[-2]&.is_a?(String) or name[-2]&. < 4 then "text-white bg-danger" end%>"><%=name[-2]%></td>
@@ -107,6 +108,7 @@
             </div>
           </div>
         <% end %>
+
 
         <br>
         <% unless @flags.include?("client blank") %>


### PR DESCRIPTION
Bug fix list:
(Non-technical explanation)
1). For students who did not submit a self-survey but received feedback from others, their average score will now be calculated correctly based on the feedback they received. Previously, their average score would display "Did not submit survey", which was inaccurate.

2). For students whose average score calculation was previously incorrect or displayed a name instead of a score, the issue has been resolved, and the average score is now correctly displayed.

These changes ensure that average scores are calculated and displayed accurately for all students, regardless of whether they submitted self-surveys or received feedback from others


(Technical explanation):
The original code only considered including_self_scores for the average score calculation, which is the sum of both self-scores (name[1]) and non-self scores (name[2]). If the self-scores were blank, it would simply push "Did not submit survey" as the average score, even if there were non-self scores available.

The new code that you have added considers three cases for calculating the average score:
1). If including_self_scores is present (i.e., there are both self-scores and non-self scores), it calculates the average score based on the sum of both self-scores and non-self scores, just like the original code did.

2). If including_self_scores is not present but there are non-self scores (name[2]), it calculates the average score based on non-self scores only. This is the case for [student], who did not submit a self-survey but received feedback from others. So, their average score is now correctly calculated based on the non-self scores.

3). If neither including_self_scores nor non-self scores (name[2]) are present, it pushes "Did not submit survey" as the average score, indicating that there is no data to calculate the average score.


As for the other bug discovered:
1). For some [students], it seems that the issue was related to the calculation of the average score using the including_self_scores. The new code fixed his issue as well, most likely because it now considers non-self scores separately when self-scores are not available.